### PR TITLE
[codex] Reduce post tag density and restore local Hugo preview

### DIFF
--- a/content/post/2023-12-18-first-post/index.md
+++ b/content/post/2023-12-18-first-post/index.md
@@ -2,7 +2,7 @@
 title: Adventures in Hugo-land
 subtitle: Or How to Spend Your Holiday Break Learning About Hugo and Deploying Your First Site
 date: 2023-12-21
-tags: ["hugo", "git", "github", "github actions", "github cli", "github pages", "markdown"]
+tags: ["hugo", "git", "github", "github actions", "github pages"]
 ---
 
 Are you bored of the same old Christmas traditions? Do you want to spice up your holiday season with some geeky fun? If so, you might want to try learning about Hugo and creating and deploying your first Hugo site to GitHub Pages!

--- a/content/post/2024-05-27-second-post/index.md
+++ b/content/post/2024-05-27-second-post/index.md
@@ -1,7 +1,7 @@
 ---
 title: It's Been A While
 date: 2024-05-27T10:56:18-04:00
-tags: ["aws", "azure", "gcp", "cloud", "genai", "llm", "apple"]
+tags: ["cloud", "aws", "azure", "gcp", "genai"]
 ---
 
 Welp seems like I failed at actually maintaining this site once I stood it up at the end of the year last year.  I did manage to move my resume details into the [About](https://waltodders.com/page/about/) Section of this site and retire the resume site that I originally stood up as part of participating in the Cloud Resume Challenge. Outside of that update things have been totally stagnate here.
@@ -56,7 +56,6 @@ I have decided to at least start capturing the articles I have come across that 
 ## **Conclusion:**
 
 Out of all of the articles the one that is the most on my mind is the IBM Buying HashiCorp article.  Why?  Simply because I myself am currently trying to figure out whether moving to something like Terraform or OpenTofu is the right thing to do right now.  I struggle pivoting away from the native IaC offerings, at least from Azure and AWS (seems to me at least last time I check Google doesn't really like there own IaC solution and would rather folks just use Terraform).  We have dedicated cloud infrastructure teams that are focused on each of the cloud platforms each with expertise in the native IaC offering within each of the cloud platforms.  Azure Bicep is a really powerful and robust offering within Azure, which makes pivoting to a 3rd party offering in Azure difficult, even though Biceps is essentially Azure Only.  With AWS, CloudFormation is nice, but if you ever have to actually introduce logic in your CloudFormation templates it gets ugly fast, and yes I know there is the CDK and I can get the power of the programming language of my choice, but then I have try and standardize on a language, a divisive effort on its own, and then upskill everyone on CDK and a language.  Terraform bring with it the fact that most everyone that has worked with any of the CSP's deploying cloud native applications and infrastructure has had some exposure to Terraform, which make it attractive to move towards from common solution perspective.  In my mind our biggest reason to move toward a 3rd party IaC solution would be maturity and expansion of multi-cloud development and architectures in an enterprise cloud infrastructure environment where no cross-cloud centralized deployment mechanism exists. I will leave it at that for now.
-
 
 
 

--- a/content/post/2024-07-02/index.md
+++ b/content/post/2024-07-02/index.md
@@ -1,7 +1,7 @@
 ---
 title: Lucky To Make It Once A Month
 date: 2024-07-02T13:23:05-0400
-tags: ["advanced-ai", "ai", "ai-governance", "ai-optimization", "ai-reliability", "ai-security", "anthropic", "automation", "azure", "claude", "cloud-computing", "cyber-security", "data-science", "developer-experience", "ethical-ai", "enterprise-architecture", "fin-ops", "generative-ai", "github-repo", "gtp-4", "juypter-notebooks", "langchain", "llm", "machine-learning", "nlp", "openai", "personal-development", "projects", "python", "rag", "responsible-ai", "security"]
+tags: ["ai", "llm", "cloud-computing", "cyber-security", "developer-experience"]
 ---
 
 Wow.  So it's be another long while, since I got around to creating another post. This one is another link list, based what has caught my eye over the last month.  Can't say I have read them all, but good list to come back to as time permits.  
@@ -57,7 +57,7 @@ Something I did decide to do based on having all of these articles, was to creat
 
 ## Artificial Intelligence and Machine Learning
 
-**Category Tags:** *#ai, #advanced-ai, #ai-applications, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #ai-trust, #responsible-ai, #ethical-ai, #generative-ai, #llm, #machine-learning, #nlp, #transformer, #neural-network, #langchain, #chatgpt, #gpt-4, #data-science, #data-protection, #data-security, #dataset-contamination, #model-overfitting, #learning, #visualization*
+**Category Tags:** *#ai, #generative-ai, #llm, #machine-learning, #ai-security*
 
 -----
 
@@ -83,7 +83,7 @@ Something I did decide to do based on having all of these articles, was to creat
 
 **Summary:** The article discusses the total cost of ownership (TCO) for deploying Generative AI models in production, emphasizing that costs go beyond just raw compute pricing and also includes factors such as container services, networking, load balancing, autoscaling, and more. Hidden costs can impact TCO, with self-built solutions potentially being initially cheaper but requiring additional expenses for development time and maintenance, especially when hiring skilled professionals. The article suggests that opting for managed services with integrated support may be more cost-effective in the long run, as understanding the full cost of deploying Generative AI models is crucial for making informed decisions.
 
-**Tags:** *\#generative-ai, \#tco, \#infra-costs", \#deployment-strategies, \#operational-efficiency*
+**Tags:** *\#generative-ai, \#tco, \#infra-costs, \#deployment-strategies, \#operational-efficiency*
 
 ### [What We Learned from a Year of Building with LLMs (Part I)](https://www.oreilly.com/radar/what-we-learned-from-a-year-of-building-with-llms-part-i/)
 
@@ -121,7 +121,7 @@ Something I did decide to do based on having all of these articles, was to creat
 
 **Summary:** The article delves deep into recent advancements in Large Language Models, exploring various model architectures such as Encoder-Only, Decoder-Only, and Encoder-Decoder models. It discusses the performance comparison between Causal Decoder (CD) and Encoder-Decoder (ED) models, highlighting key findings from a study on language model architecture and pre-training objectives. Additionally, the article touches on important factors like training cost, emergent abilities in LLMs, in-context learning from prompts, efficiency optimization, and the
 
-**Tags:** *\#llm, \#encoder-decoder-models, \#ai-optimization", \#ai*
+**Tags:** *\#llm, \#encoder-decoder-models, \#ai-optimization, \#ai*
 
 ### [[2406.11903] A Survey of Large Language Models for Financial Applications: Progress, Prospects and Challenges](https://arxiv.org/abs/2406.11903)
 
@@ -169,7 +169,7 @@ Something I did decide to do based on having all of these articles, was to creat
 
 **Summary:** The article discusses the author's keynote at the AI Engineer World's Fair, where they highlighted advancements in the LLM space since the previous AI Engineer Summit 8 months ago. The author focused on breaking the GPT-4 barrier and discussed various models available in the space, emphasizing the need for responsible use and open challenges in AI engineering. They also touched on the AI trust crisis, prompt injection issues, and the concept of "slop" - unrequested and unreviewed AI-generated content.
 
-**Tags:** *\#ai-engineering, \#llm, \#ai-trust, \#gtp4, #ai-responsible-use*
+**Tags:** *\#ai-engineering, \#llm, \#ai-trust, \#gpt-4, \#responsible-ai*
 
 ### [Build Rag With Llamaindex To Make LLM Answer About Yourself, Like in an Interview or About General InformationI](https://pub.towardsai.net/build-rag-with-llamaindex-to-make-llm-answer-about-yourself-like-in-interview-or-about-general-68bb2037f8b6?gi=d379a686b47c)
 
@@ -179,7 +179,7 @@ Something I did decide to do based on having all of these articles, was to creat
 
 **Summary:** The article discusses the implementation of a RAG (Retrieved Augmentation Generation) pipeline using Llamaindex for building chat applications with LLMs like Cohere. It explains the process of setting up the pipeline, loading documents, parsing text into nodes, obtaining vector embeddings, and using a chat engine with a retrieval strategy. The pipeline leverages Cohere for LLM and Qdrant for storing vector embeddings, allowing for personalized responses based on user queries. The article also provides code examples for
 
-**Tags:** *\#nlp, \#ai, \#rag, \#chatbot
+**Tags:** *\#nlp, \#ai, \#rag, \#chatbot*
 
 ### [Build your own Large Language Model (LLM) From Scratch Using PyTorch](https://pub.towardsai.net/build-your-own-large-language-model-llm-from-scratch-using-pytorch-9e9945c24858?gi=a3b1cede2202)
 
@@ -235,7 +235,7 @@ Something I did decide to do based on having all of these articles, was to creat
 
 ## Cloud Computing and Infrastructure
 
-**Categorical Tags:** *#cloud-computing, #cloud, #azure, #openai, #cloud-migration, #platform-engineering, #platform-strategies, #platform-integration, #internal-developer-platforms*
+**Categorical Tags:** *#cloud-computing, #cloud, #platform-engineering, #cloud-migration, #internal-developer-platforms*
 
 -----
 
@@ -339,7 +339,7 @@ The impact of the attack is
 
 ## Development and Programming
 
-**Categorical Tags:** *#programming, #python, #github-repo, #developer-productivity, #juypter-notebooks, #tools, #devx, #projects, #api, #learning, #skills-development, #personal-growth, #professional-development*
+**Categorical Tags:** *#programming, #python, #tools, #devx, #projects*
 
 -----
 
@@ -399,7 +399,7 @@ The impact of the attack is
 
 **Summary:** Claude Engineer is a CLI tool that utilizes Anthropic's Claude-3.5-Sonnet model to aid in software development tasks by combining a large language model with file system operations and web search capabilities. Its features include interactive chat interface, file system operations, web search using Tavily API, syntax highlighting, project structure management, and code analysis. To install Claude Engineer, clone the repository, install dependencies, and set up your Anthropic and Tavily API keys within the script.
 
-**Tags:** *\#tools, \#claude, \#anthropic, \#api, \#github-repo, \#projects*
+**Tags:** *\#tools, \#claude, \#anthropic, \#github-repo, \#projects*
 
 ### [Why we no longer use LangChain for building our AI agents](https://www.octomind.dev/blog/why-we-no-longer-use-langchain-for-building-our-ai-agents)
 
@@ -419,7 +419,7 @@ The impact of the attack is
 
 **Summary:** Thread is a Jupyter alternative that integrates an AI copilot into your Jupyter Notebook editing experience.  Best of all, Thread runs locally and can be used for free with Ollama or your own API key.
 
-**Tags:** *\#github-repo, \#tools, \#juypter-notebooks, \#projects*
+**Tags:** *\#github-repo, \#tools, \#jupyter-notebook, \#projects*
 
 ### [Every Way To Get Structured Output From LLMs](https://www.boundaryml.com/blog/structured-output-from-llms)
 
@@ -439,4 +439,4 @@ The impact of the attack is
 
 **Summary:** The article discusses five favorite ways to keep technical skills sharp, including working on side projects to experiment with new language features, practicing with Koans to find enlightenment in programming, engaging in coding Katas like Gilded Rose and Vending Machine, researching for weekly interesting links posts, and consuming video content from sources like Pluralsight and Udemy to stay updated with new technologies. The author emphasizes the importance of continuously updating technical skills due to the rapid pace of change in technology, advocating for proactive learning
 
-**Tags:** *\#learning", \#skills-development", \#personal-growth, \#professional-development*
+**Tags:** *\#learning, \#skills-development, \#personal-growth, \#professional-development*

--- a/content/post/2024-07-04/index.md
+++ b/content/post/2024-07-04/index.md
@@ -1,7 +1,7 @@
 ---
 title: Born on the 4th of July
 date: 2024-07-03T21:40:21
-tags: ["agi", "ai", "ai-optimization", "ai-security", "automation", "azure", "bias", "cloud", "data-science", "deep-learning", "developer-experience", "docker", "ethical-ai", "generative-ai", "github", "jupyter-notebook", "llm", "machine-learning", "markdown", "nlp", "openai", "privacy", "projects", "python", "rag", "responsible-ai", "security", "tools"]
+tags: ["ai", "llm", "developer-experience", "responsible-ai", "data-science"]
 ---
 
 As in this post was born on the 4th of July.  Nothing more than that.  Just a dumb title to a silly link post for the holiday.  I actually had a chance to read through and have thoughts on some of these articles, there's that as well.  Enjoy.
@@ -28,7 +28,7 @@ As in this post was born on the 4th of July.  Nothing more than that.  Just a du
 
 ## Artificial Intelligence and Machine Learning
 
-**Category Tags:** #ai, #agi, #ai-optimization, #machine-learning, #deep-learning, #nlp, #generative-ai
+**Category Tags:** #ai, #machine-learning, #deep-learning, #nlp, #generative-ai
 
 ### [The Five Stages Of AI Grief - NOEMA](https://www.noemamag.com/the-five-stages-of-ai-grief/)
 
@@ -92,7 +92,7 @@ Great article.  I found several points raised within the article intriguing:
 
 ## Development and Programming
 
-**Category Tags:** #python, #developer-experience, #jupyter-notebook, #markdown, #projects, #tools
+**Category Tags:** #python, #developer-experience, #jupyter-notebook, #projects, #tools
 
 ### [Meet Verba 1.0: Run State-of-the-Art RAG Locally with Ollama Integration and Open Source Models - MarkTechPost](https://www.marktechpost.com/2024/05/19/meet-verba-1-0-run-state-of-the-art-rag-locally-with-ollama-integration-and-open-source-models/?amp=)
 
@@ -174,7 +174,7 @@ Putting it in my projects to try queue to try out.
 
 ## Cybersecurity and Responsible AI
 
-**Category Tags:** #i-security, #responsible-ai, #ethical-ai, #privacy, #security, #bias
+**Category Tags:** #ai-security, #responsible-ai, #ethical-ai, #privacy, #security
 
 ### [Mitigating Skeleton Key, a new type of generative AI jailbreak technique | Microsoft Security Blog](https://www.microsoft.com/en-us/security/blog/2024/06/26/mitigating-skeleton-key-a-new-type-of-generative-ai-jailbreak-technique/)
 

--- a/content/post/2024-07-15/index.md
+++ b/content/post/2024-07-15/index.md
@@ -1,7 +1,7 @@
 ---
 title: Where Did All The Time Go?
 date: 2024-07-15T20:01:17
-tags: ["access-management", "agi", "ai", "ai-agents", "ai-cloud", "ai-governance", "ai-in-biomedicine", "ai-optimization", "ai-reliability", "ai-security", "ai-toolkit", "amazon-s3", "amazon-ses", "anthropic", "automation", "aws", "aws-s3", "aws-whoami", "azure", "bastion-host", "biomedical-sciences", "biotech-innovation", "books", "breakthroughs", "building-trust", "business-transformation", "career-advice", "cicd", "claude", "cli", "clinical-trials", "cloud", "cloud-computing", "cost-tracking", "crewAI", "critical-thinking", "cyber-security", "data-access", "data-integration", "data-science", "data-security", "declarative-configuration", "deep-learning", "deepmind", "deepnote", "default-tags", "dev-ops", "developer-experience", "docker", "ec2", "ec2-tagging", "education", "eigenvalues", "email-forwarding", "enterprise-architecture", "ethica-ai", "ethical-ai", "evolving-workforce", "exemplars", "experimental-biology", "feature-engineering", "few-shot", "gcp", "gene-therapy", "generative-ai", "genomics", "github", "github-actions", "github-repo", "go", "goodreads", "gpt-4", "healthcare-advancements", "human-nature", "iac", "iam", "identity-and-access-management", "identity-management", "information-retrieval", "journaling-prompts", "json", "knowledge", "knowledge-graphs", "knowledge-management", "lambda", "lambda-function", "langchain", "language-model", "learning", "life-changing", "linear-algebra", "linux", "llama", "llm", "machine-learning", "matrices", "mental-models", "meta", "model-optimization", "model-training", "models", "multi-agent-systems", "multimodal-learning", "neural-networks", "newsletter", "nlp", "note-taking", "obsidian", "ollama", "omnics", "open-source", "openai", "optimization"]
+tags: ["ai", "llm", "aws", "security", "machine-learning"]
 ---
 
 Just a whole lotta links this time around.  Didn't have a chance to really dig into any of them to provide any kind of commentary or thoughts or opinions.  Some good state-of-ai think pieces here, a handful of potential learning projects and some AWS cloud related articles this time around, that I definately want to dig into some more.  
@@ -37,11 +37,11 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ## **AI and Machine Learning**
 
-**Category Tags:** #agi, #ai, #ai-agents, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #ai-toolkit, #anthropic, #automation, #aws, #building-trust, #business-transformation, #claude, #cloud, #cloud-computing, #crewAI, #data-science, #data-security, #deep-learning, #deepmind, #deepnote, #developer-experience, #eigenvalues, #ethica-ai, #ethical-ai, #evolving-workforce, #feature-engineering, #gcp, #generative-ai, #github, #gpt-4, #information-retrieval, #langchain, #language-model, #linear-algebra, #llama, #llm, #machine-learning, #matrices, #meta, #model-optimization, #model-training, #models, #multi-agent-systems, #multimodal-learning, #neural-networks, #nlp, #ollama, #open-source, #openai, #optimization, #productivity-improvement, #projects, #prompt-engineering, #python, #rag, #recommendation-systems, #research, #research-paper, #responsible-ai, #retrieval-augmented-generation, #scaling-ai, #technology-management, #training-data, #value-creation, #vector-space, #visual-studio-code, #windows-11
+**Category Tags:** #ai, #llm, #machine-learning, #generative-ai, #deep-learning
 
 ### [Preliminary Notes on the Delvish Dialect, by Bruce Sterling | by Bruce Sterling | Jul, 2024 | Medium](https://bruces.medium.com/preliminary-notes-on-the-delvish-dialect-by-bruce-sterling-ce68a476247b)
 
-**Tags:** *#llm, #machine-learning, #deep-learning, #ai, #generative-ai, #ethical-ai, #python, #nlp, #openai, #rag*
+**Tags:** *#llm, #ai, #generative-ai, #machine-learning, #nlp*
 
 **Site Name:** Medium
 
@@ -51,7 +51,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [us-state-of-gen-ai-report-q2](https://storage.googleapis.com/omnivore/u/554e05cf-049d-435b-8ba3-fa22bd56df75/us-state-of-gen-ai-report-q2.pdf?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=omnivore-production%40appspot.gserviceaccount.com%2F20240715%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240715T235545Z&X-Goog-Expires=14400&X-Goog-SignedHeaders=host&X-Goog-Signature=b585559baa19da27623b97559bdbad7343ef2779edd0b96836fc5de6711b4cd9fb04a4bf3870625322ff6c42b2c1acfc81a10425d4f310e81659b4ccc56974685d5e214a6d04dca9b01f6410a328cfb836dbdd37f97a4c571b330c23b2cd23901a8b0143c248b497a747382484f9b901dff2dd2f84bfa8233b9e094f8a5a2532ab68ad5c291015bb1ccdb558dd651b4391c8dd9f9baa775320988737bdb20fe87a02cbefb67ee4aea6ec23e2c878cb04367277607f5f66573ea1896a731e444e091194e09f233947d88fade654fabd47132709ea4fc2dc1d7fcb68cdb44e8b2381084ee833dbddd9ec3d33df4276e5b82d93201680591592e0a27fadf67df8dd)
 
-**Tags:** *#ai, #generative-ai, #value-creation, #scaling-ai, #building-trust, #evolving-workforce, #data-security, #technology-management, #business-transformation, #productivity-improvement*
+**Tags:** *#generative-ai, #business-transformation, #productivity-improvement, #building-trust, #data-security*
 
 **Site Name:** None
 
@@ -61,7 +61,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [FlashAttention-3: Fast and Accurate Attention with Asynchrony and Low-precision | Tri Dao](https://tridao.me/blog/2024/flash3/)
 
-**Tags:** *#ai, #machine-learning, #deep-learning, #llm, #nlp, #gpt-4, #gcp, #python, #data-science, #cloud-computing*
+**Tags:** *#llm, #deep-learning, #machine-learning, #ai, #nlp*
 
 **Site Name:** tridao.me
 
@@ -71,7 +71,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [The AI summer — Benedict Evans](https://www.ben-evans.com/benedictevans/2024/7/9/the-ai-summer)
 
-**Tags:** *#ai, #ai-security, #automation, #generative-ai, #gpt-4, #llm, #machine-learning, #nlp, #openai, #projects*
+**Tags:** *#ai, #generative-ai, #llm, #gpt-4, #openai*
 
 **Site Name:** Benedict Evans
 
@@ -81,7 +81,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [AI Conundrums – tecosystems](https://redmonk.com/sogrady/2024/07/03/ai-conundrums/)
 
-**Tags:** *#ai, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #cloud, #deep-learning, #generative-ai, #open-source, #training-data*
+**Tags:** *#ai, #ai-governance, #ai-reliability, #ai-security, #generative-ai*
 
 **Site Name:** tecosystems
 
@@ -91,7 +91,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [Prompt engineering techniques and best practices: Learn by doing with Anthropic’s Claude 3 on Amazon Bedrock | AWS Machine Learning Blog](https://aws.amazon.com/blogs/machine-learning/prompt-engineering-techniques-and-best-practices-learn-by-doing-with-anthropics-claude-3-on-amazon-bedrock/)
 
-**Tags:** *#anthropic, #aws, #claude, #prompt-engineering, #generative-ai, #llm, #machine-learning, #nlp, #cloud-computing, #ai-optimization*
+**Tags:** *#anthropic, #aws, #claude, #prompt-engineering, #llm*
 
 **Site Name:** Amazon Web Services
 
@@ -101,7 +101,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [Superintelligence—10 years later - by Conrad Gray](https://www.humanityredefined.com/p/superintelligence10-years-later)
 
-**Tags:** *#ai, #ai-governance, #ai-reliability, #ai-security, #agi, #anthropic, #automation, #gpt-4, #machine-learning, #responsible-ai*
+**Tags:** *#agi, #ai, #ai-governance, #ai-reliability, #responsible-ai*
 
 **Site Name:** Humanity Redefined
 
@@ -111,7 +111,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [[2402.14905] MobileLLM: Optimizing Sub-billion Parameter Language Models for On-Device Use Cases](https://arxiv.org/abs/2402.14905)
 
-**Tags:** *#llm, #meta, #research-paper, #machine-learning, #deep-learning, #generative-ai, #gpt-4, #cloud, #cloud-computing, #ai-optimization*
+**Tags:** *#llm, #research-paper, #machine-learning, #deep-learning, #ai-optimization*
 
 **Site Name:** arXiv.org
 
@@ -121,7 +121,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [2406.17711v1](https://storage.googleapis.com/omnivore/u/1934bfee-02b8-41c6-91ef-bc36d1bd5d10/2406.17711v1.pdf?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=omnivore-production%40appspot.gserviceaccount.com%2F20240715%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240715T235545Z&X-Goog-Expires=14400&X-Goog-SignedHeaders=host&X-Goog-Signature=261ee259d0c7a8f481d88416385ddd614d580ffed2b277220f0eb921a2fa324c76c5fb129b9ae29f1df928bab90248abdc253aa5bdd2b2d9eb08734a53297166361ebd3553ff4677e3a1cf0d6c1f6042bcd5364a1ded5e80d22de697da451eca46e89b1a913ba83d16ae87a37aa58d7ce5d6446d4fedb22836c7f630352e3df747ed841649714bb2d1d74eac70e1c15a61b4c510b6e31e21628e264f45f3d062edbb9243a9d11e6b1133ad11fb869d1625c92c79291da879f7cc0cc861686d6e525159e13f84224edb5edb70bfa1212e11eb30ca805b24975200a46cf8306d8515d03f648a9e4f3aec248a608d8c59d9fb78aafcc0d8fa721dd9b8390c05212d)
 
-**Tags:** *#ai, #deepmind, #research-paper, #deep-learning, #machine-learning, #data-science, #model-optimization, #model-training, #multimodal-learning, #neural-networks*
+**Tags:** *#research-paper, #multimodal-learning, #machine-learning, #model-training, #deep-learning*
 
 **Site Name:** None
 
@@ -131,7 +131,7 @@ Just a whole lotta links this time around.  Didn't have a chance to really dig i
 
 ### [Linear Algebra Concepts Every Data Scientist Should Know | by Benedict Neo | bitgrit Data Science Publication | Jun, 2024 | Medium](https://medium.com/bitgrit-data-science-publication/linear-algebra-concepts-every-data-scientist-should-know-18b00bd453dd)
 
-**Tags:** *#data-science, #machine-learning, #linear-algebra, #optimization, #feature-engineering, #recommendation-systems, #deepnote, #matrices, #vector-space, #eigenvalues*
+**Tags:** *#data-science, #machine-learning, #linear-algebra, #matrices, #vector-space*
 
 **Site Name:** bitgrit Data Science Publication
 
@@ -153,7 +153,7 @@ Matrix
 
 ### [Multi AI Agent Systems 101. Automating Routine Tasks in Data Source… | by Mariya Mansurova | Jun, 2024 | Towards Data Science](https://towardsdatascience.com/multi-ai-agent-systems-101-bac58e3bcc47?gi=4dd957d4452d)
 
-**Tags:** *#ai-agents, #llm, #rag, #multi-agent-systems, #automation, #data-science, #deep-learning, #langchain, #crewAI, #openai*
+**Tags:** *#ai-agents, #multi-agent-systems, #llm, #automation, #rag*
 
 **Site Name:** Towards Data Science
 
@@ -163,7 +163,7 @@ Matrix
 
 ### [How To Run Llama 3 In Visual Studio Code — A Step-By-Step Guide | by Jim Clyde Monge | Generative AI](https://generativeai.pub/how-to-run-llama-3-in-visual-studio-code-with-codegpt-18cb105cf9d5?gi=1738c83f1552)
 
-**Tags:** *#llama, #llm, #projects, #visual-studio-code, #meta, #open-source, #language-model, #ollama, #windows-11, #ai*
+**Tags:** *#llama, #llm, #visual-studio-code, #open-source, #ollama*
 
 **Site Name:** Generative AI
 
@@ -173,7 +173,7 @@ Matrix
 
 ### [Gradually, then Suddenly: Upon the Threshold](https://www.oneusefulthing.org/p/gradually-then-suddenly-upon-the)
 
-**Tags:** *#ai, #ai-optimization, #ai-reliability, #ai-security, #automation, #claude, #gpt-4, #deep-learning, #ethica-ai, #data-science*
+**Tags:** *#ai, #ai-optimization, #ai-reliability, #gpt-4, #claude*
 
 **Site Name:** One Useful Thing
 
@@ -183,7 +183,7 @@ Matrix
 
 ### [GitHub - karpathy/LLM101n: LLM101n: Let's build a Storyteller](https://github.com/karpathy/LLM101n)
 
-**Tags:** *#github, #llm, #projects, #ai, #generative-ai, #deep-learning, #python, #cloud-computing, #cloud, #developer-experience*
+**Tags:** *#github, #llm, #projects, #python, #generative-ai*
 
 **Site Name:** GitHub
 
@@ -193,7 +193,7 @@ Matrix
 
 ### [Meet Verba 1.0: Run State-of-the-Art RAG Locally with Ollama Integration and Open Source Models - MarkTechPost](https://www.marktechpost.com/2024/05/19/meet-verba-1-0-run-state-of-the-art-rag-locally-with-ollama-integration-and-open-source-models/?amp=)
 
-**Tags:** *#rag, #llm, #github, #projects, #retrieval-augmented-generation, #ai, #information-retrieval, #research, #ai-toolkit, #models*
+**Tags:** *#rag, #llm, #retrieval-augmented-generation, #information-retrieval, #ai-toolkit*
 
 **Site Name:** MarkTechPost
 
@@ -205,11 +205,11 @@ Matrix
 
 ## **Cloud Computing and Security**
 
-**Category Tags:** #access-management, #amazon-s3, #amazon-ses, #automation, #aws, #aws-s3, #aws-whoami, #bastion-host, #cli, #cloud, #cloud-computing, #cyber-security, #data-access, #data-integration, #dev-ops, #developer-experience, #docker, #ec2, #email-forwarding, #enterprise-architecture, #ethical-ai, #github, #github-actions, #go, #iam, #identity-and-access-management, #identity-management, #json, #lambda, #lambda-function, #linux, #machine-learning, #projects, #python, #responsible-ai, #security, #serverless-computing, #session-manager, #single-sign-on, #terraform, #vpc
+**Category Tags:** #aws, #security, #cloud-computing, #identity-management, #automation
 
 ### [Strategies for achieving least privilege at scale – Part 2 | AWS Security Blog](https://aws.amazon.com/blogs/security/strategies-for-achieving-least-privilege-at-scale-part-2/)
 
-**Tags:** *#aws, #cyber-security, #cloud-computing, #security, #developer-experience, #python, #automation, #ethical-ai, #responsible-ai, #projects*
+**Tags:** *#aws, #security, #cloud-computing, #cyber-security, #automation*
 
 **Site Name:** Amazon Web Services
 
@@ -219,7 +219,7 @@ Matrix
 
 ### [Strategies for achieving least privilege at scale – Part 1 | AWS Security Blog](https://aws.amazon.com/blogs/security/strategies-for-achieving-least-privilege-at-scale-part-1/)
 
-**Tags:** *#aws, #security, #cloud, #cloud-computing, #dev-ops, #enterprise-architecture, #automation, #developer-experience, #machine-learning, #identity-and-access-management*
+**Tags:** *#aws, #security, #cloud-computing, #identity-and-access-management, #automation*
 
 **Site Name:** Amazon Web Services
 
@@ -229,7 +229,7 @@ Matrix
 
 ### [secured-bastion-host-terraform/README.md at main · aws-samples/secured-bastion-host-terraform · GitHub](https://github.com/aws-samples/secured-bastion-host-terraform/blob/main/README.md)
 
-**Tags:** *#aws, #ec2, #bastion-host, #iam, #session-manager, #terraform, #vpc, #security, #linux, #cloud-computing*
+**Tags:** *#aws, #ec2, #bastion-host, #terraform, #vpc*
 
 **Site Name:** github.com
 
@@ -242,7 +242,7 @@ to such server.
 
 ### [Access AWS services programmatically using trusted identity propagation | AWS Security Blog](https://aws.amazon.com/blogs/security/access-aws-services-programmatically-using-trusted-identity-propagation/)
 
-**Tags:** *#aws, #security, #single-sign-on, #identity-management, #cli, #data-access, #cloud-computing, #data-integration, #access-management, #amazon-s3*
+**Tags:** *#aws, #security, #identity-management, #single-sign-on, #access-management*
 
 **Site Name:** Amazon Web Services
 
@@ -252,7 +252,7 @@ to such server.
 
 ### [bullfrog/README.md at main · bullfrogsec/bullfrog · GitHub](https://github.com/bullfrogsec/bullfrog/blob/main/README.md)
 
-**Tags:** *#github, #github-actions, #security, #cloud-computing, #cloud, #automation, #aws, #docker, #developer-experience*
+**Tags:** *#github, #github-actions, #security, #aws, #automation*
 
 **Site Name:** GitHub
 
@@ -262,7 +262,7 @@ to such server.
 
 ### [aws-whoami-golang/README.md at main · benkehoe/aws-whoami-golang · GitHub](https://github.com/benkehoe/aws-whoami-golang/blob/main/README.md)
 
-**Tags:** *#aws, #github, #aws-whoami, #go, #cloud-computing, #cli, #developer-experience, #json, #security, #iam*
+**Tags:** *#aws, #aws-whoami, #go, #cli, #iam*
 
 **Site Name:** GitHub
 
@@ -272,7 +272,7 @@ to such server.
 
 ### [Forward Incoming Email to an External Destination | AWS Messaging & Targeting Blog](https://aws.amazon.com/blogs/messaging-and-targeting/forward-incoming-email-to-an-external-destination/)
 
-**Tags:** *#aws, #amazon-ses, #lambda, #cloud-computing, #cloud, #aws-s3, #iam, #serverless-computing, #email-forwarding, #lambda-function*
+**Tags:** *#aws, #amazon-ses, #lambda, #email-forwarding, #serverless-computing*
 
 **Site Name:** Amazon Web Services
 

--- a/content/post/2024-08-18/index.md
+++ b/content/post/2024-08-18/index.md
@@ -1,7 +1,7 @@
 ---
 title: Dog Days of Summer, What Does It Mean?
 date: 2024-08-18T13:35:05
-tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliability", "ai-security", "anthopic", "anthropic", "api-keys", "api-reliability", "api-security", "apple", "application-security", "architecture", "artificial-intelligence", "attention-mechanism", "attribute-based-access-control", "authentication", "authentication-methods", "authorization", "automation", "aws", "aws-secrets-manager", "aws-security", "azure", "biometric-authentication", "boosting", "causal-ai", "ci-cd", "cicd", "ciso", "clgob", "cli-tools", "cloud", "cloud-computing", "cloud-security", "coding", "command-line", "command-line-utility", "conda", "configuration", "coreml", "cryptography", "cyber-security", "cybersecurity", "data-science", "data-security", "data-structures", "decision-tree", "deep-learning", "dependency-management", "developer-experience", "developer-experience", "developer-productivity", "development", "development-tools", "devops", "devx", "docker", "drug-development", "editor", "embedding", "ensemble-learning", "enterprise-architecture", "enterprise-research", "ethical-ai", "fast-installer", "fish", "gcp", "generative-ai", "genetic-research", "git", "github", "github-actions", "github-copilot", "gitlab-ci-cd", "gpt-3.5-turbo", "gpt-4", "gpt-4v", "graph-machine-learning", "groq", "group-management", "hashicorp", "high-confidence", "http-sessions", "iaas", "iac", "iac-tools", "identity-management", "infrastructure-as-code", "integration-architecture", "ios", "json", "json-web-token", "key-management", "kubernetes", "language-model-architecture", "large-language-models", "llm", "llm2sh", "machine-learning", "machine-to-machine-authentication", "macos", "math-of-transformers", "mathematical-algorithms", "microsoft-research", "model-autonomy", "multifactor-authentication", "multimodal-data", "neovim", "neural-networks", "nlp", "oauth-2-0", "openai", "openid-connect", "package-installer", "package-management", "pattern-recognition", "pip", "policy-management", "predictive-text", "preparedness-framework", "private-datasets", "project-management", "projects", "python", "python-environments", "python-package", "rag", "red-teaming", "requirements", "responsible-ai", "reverse-engineering", "risk-evaluation", "role-based-access-control", "rust", "salary", "security", "security", "selected from available tags", "shell", "shell-commands", "sklearn", "stack-overflow", "survey", "terminal", "terraform", "text-embeddings", "tokens", "tools", "transformer-architecture", "transformer-language-model", "transformers", "user-management", "uv", "virtualenv", "vscode-ai", "web-cookies", "webdev", "yolo-mode"]
+tags: ["terraform", "ai", "security", "python", "developer-productivity"]
 ---
 
 > According to the Farmers’ Almanac, the phrase originated in ancient Roman times. The Romans noticed that the star they called Sirius, the Dog Star, was in conjunction with the sun in late July. They believed the Dog Star’s brightness made things hotter on Earth during the late summer months. So, they named this period diēs caniculārēs, or “days of the dog star,” which was later shortened to “dog days." - As quoted from *Saturday 17-Aug-2024* **Morning Brew Newsletter**, who apparently got it from the **Farmers' Almanac**
@@ -53,11 +53,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## Terraform
 
-**Category Tags:** #ai-security, #api-reliability, #api-security, #architecture, #automation, #aws, #aws-secrets-manager, #azure, #ci-cd, #ciso, #cloud, #cloud-computing, #cloud-security, #coding-best-practices, #cyber-security, #data-science, #data-security, #data-structures, #deep-learning, #dependency-management, #developer-experience, #development-tools, #devops, #enterprise-architecture, #ethical-ai, #fast-installer, #gcp, #github, #github-actions, #gitlab-ci-cd, #group-management, #hashicorp, #high-confidence, #iaas, #iac, #iac-tools, #identity-management, #infrastructure-as-code, #integration-architecture, #json, #key-management, #machine-to-machine-authentication,  #package-installer, #policy-management, #project-management, #python, #python-package, #rust, #security, #terraform, #user-management, #uv
+**Category Tags:** #terraform, #infrastructure-as-code, #security, #aws, #automation
 
 ### [Terraform Functions And Expressions Explained | Build5Nines](https://build5nines.com/terraform-functions-and-expressions-explained/)
 
-**Tags:** *#terraform, #hashicorp, #iaas, #infrastructure-as-code, #aws, #azure, #gcp, #automation, #data-structures, #json*
+**Tags:** *#terraform, #hashicorp, #infrastructure-as-code, #data-structures, #json*
 
 **Site Name:** Build5Nines
 
@@ -67,7 +67,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Fwd: Dynamic Terraform Configurations with try and for_each Functions](https://omnivore.app/no_url?q=66a92214-8c62-40dd-8365-5d8704fec857)
 
-**Tags:** *#terraform, #azure, #cloud, #security, #cloud-computing, #automation, #aws, #data-science, #developer-experience, #coding-best-practices*
+**Tags:** *#terraform, #automation, #security, #cloud-computing, #coding-best-practices*
 
 **Site Name:** omnivore.app
 
@@ -77,7 +77,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [terraform-pr-commenter/README.md at master · robburger/terraform-pr-commenter · GitHub](https://github.com/robburger/terraform-pr-commenter/blob/master/README.md)
 
-**Tags:** *#github-actions, #terraform, #aws, #cloud, #cloud-computing, #cyber-security, #data-science, #deep-learning, #developer-experience, #ethical-ai*
+**Tags:** *#github-actions, #terraform, #aws, #automation, #developer-experience*
 
 **Site Name:** github.com
 
@@ -87,7 +87,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Top Terraform Tools to Know in 2024 | by env0 Team | env0 | Medium](https://medium.com/env0/top-terraform-tools-to-know-in-2024-a00a232bb936)
 
-**Tags:** *#terraform, #ai-security, #aws, #azure, #cloud, #cloud-computing, #cyber-security, #infrastructure-as-code, #iac-tools, #security
+**Tags:** *#terraform, #infrastructure-as-code, #iac-tools, #security, #cloud-computing*
 
 **Site Name:** env0
 
@@ -97,7 +97,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Topic of the Week - Infrastructure as Code (IaC) Security in 2024](https://www.cloudsecuritynewsletter.com/p/infrastructure-code-iac-security-2024)
 
-**Tags:** *#terraform, #security, #cloud-security, #infrastructure-as-code, #iac, #aws, #azure, #gcp, #cloud-computing, #ciso*
+**Tags:** *#terraform, #infrastructure-as-code, #security, #cloud-security, #iac*
 
 **Site Name:** cloudsecuritynewsletter.com
 
@@ -107,7 +107,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Issue #183 - Terraform Variable Cross Validation, 3 Use-cases for Terraform, LLRT Lambdas, Terraform Roadmap, Terramate](https://www.weekly.tf/p/issue-183-terraform-variable-cross-validation-3-use-cases-for-terraform-llrt-roadmap-terramate)
 
-**Tags:** *#terraform, #cloud, #cloud-computing, #aws, #azure, #github, #github-actions, #gitlab-ci-cd, #infrastructure-as-code, #automation*
+**Tags:** *#terraform, #infrastructure-as-code, #automation, #github-actions, #aws*
 
 **Site Name:** weekly.tf
 
@@ -117,7 +117,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [aws-ia/iam-identity-center/aws | Terraform Registry](https://registry.terraform.io/modules/aws-ia/iam-identity-center/aws/latest)
 
-**Tags:** *#aws, #terraform, #identity-management, #automation, #cloud-computing, #data-security, #user-management, #devops, #policy-management, #group-management*
+**Tags:** *#aws, #terraform, #identity-management, #user-management, #policy-management*
 
 **Site Name:** registry.terraform.io
 
@@ -129,11 +129,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## AI, Machine Learning, and Deep Learning
 
-**Category Tags:** #ai, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #anthopic, #apple, #artificial-intelligence, #attention-mechanism, #automation, #boosting, #causal-ai, #cloud, #cloud-computing, #coreml, #cybersecurity, #data-science, #decision-tree, #deep-learning, #developer-experience, #drug-development, #embedding, #employee-productivity, #ensemble-learning, #enterprise-architecture, #enterprise-research, #ethical-ai, #generative-ai, #genetic-research, #github-copilot, #gpt-4, #gpt-4v, #graph-machine-learning, #image-recognition, #ios, #language-model-architecture, #large-language-models, #llm, #machine-learning, #macos, #mathematical-algorithms, #math, #microsoft-research, #model-autonomy, #multimodal-data, #neural-networks, #nlp, #openai, #pattern-recognition, #positional-encoding, #predictive-text, #preparedness-framework, #private-datasets, #productivity-paradox, #python, #rag, #red-teaming, #responsible-ai, #risk-evaluation, #sklearn, #skill-based-approach, #survey-analysis, #text-embeddings, #transformer-language-model, #transformers
+**Category Tags:** #ai, #machine-learning, #generative-ai, #llm, #deep-learning
 
 ### [A Simple Implementation of Boosting Algorithm](https://blog.dailydoseofds.com/p/a-simple-implementation-of-boosting)
 
-**Tags:** *#machine-learning, #ai, #deep-learning, #python, #data-science, #generative-ai, #boosting, #decision-tree, #ensemble-learning, #sklearn*
+**Tags:** *#machine-learning, #python, #boosting, #ensemble-learning, #sklearn*
 
 **Site Name:** Daily Dose of Data Science
 
@@ -143,7 +143,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [GPT-4o System Card | OpenAI](https://openai.com/index/gpt-4o-system-card/)
 
-**Tags:** *#ai, #ai-security, #deep-learning, #gpt-4, #gpt-4v, #machine-learning, #model-autonomy, #preparedness-framework, #red-teaming, #risk-evaluation*
+**Tags:** *#ai, #ai-security, #gpt-4, #red-teaming, #risk-evaluation*
 
 **Site Name:** openai.com
 
@@ -153,7 +153,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [A Comparison of Top Embedding Libraries for Generative AI - MarkTechPost](https://www.marktechpost.com/2024/07/28/a-comparison-of-top-embedding-libraries-for-generative-ai/?amp=)
 
-**Tags:** *#embedding, #generative-ai, #llm, #text-embeddings, #nlp, #multimodal-data, #machine-learning, #ai, #ai-optimization, #ai-reliability*
+**Tags:** *#embedding, #generative-ai, #llm, #text-embeddings, #nlp*
 
 **Site Name:** MarkTechPost
 
@@ -163,7 +163,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Gen AI Increases Workloads and Decreases Productivity, Upwork Study Finds - InfoQ](https://www.infoq.com/news/2024/07/genai-hampers-productivity-study/)
 
-**Tags:** *#generative-ai, #ai, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #anthropic, #automation, #developer-experience, #ethical-ai*
+**Tags:** *#generative-ai, #ai, #developer-experience, #ai-reliability, #ai-governance*
 
 **Site Name:** InfoQ
 
@@ -173,7 +173,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [How to get started with LLMs 🤖](https://www.databites.tech/p/how-to-get-started-with-llms)
 
-**Tags:** *#ai, #llm, #openai, #generative-ai, #machine-learning, #transformers, #nlp, #anthopic, #deep-learning, #cloud-computing*
+**Tags:** *#llm, #openai, #generative-ai, #machine-learning, #transformers*
 
 **Site Name:** databites.tech
 
@@ -183,7 +183,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Fwd: AI Tooling for Software Engineers in 2024: Reality Check (Part 1)](https://newsletter.pragmaticengineer.com/p/ai-tooling-2024?isFreemail=true&post_id=146678491&publication_id=458709&r=3mtec&token=eyJ1c2VyX2lkIjo2MTAzMzgwLCJwb3N0X2lkIjoxNDY2Nzg0OTEsImlhdCI6MTcyMTE0NzM1MywiZXhwIjoxNzIzNzM5MzUzLCJpc3MiOiJwdWItNDU4NzA5Iiwic3ViIjoicG9zdC1yZWFjdGlvbiJ9.qWt7vzH6sgdLh8m8aegJIt36NkLN3YjNyqM74JBok5A&triedRedirect=true)
 
-**Tags:** *#ai, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #anthropic, #automation, #developer-experience, #generative-ai, #github-copilot*
+**Tags:** *#ai, #generative-ai, #developer-experience, #github-copilot, #anthropic*
 
 **Site Name:** newsletter.pragmaticengineer.com
 
@@ -193,7 +193,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [SoET Report 2024](https://storage.googleapis.com/omnivore/u/317bd9e4-ce27-414f-9a8a-6554a982233b/SoETReport2024.pdf?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=gke-app-internal-sa%40omnivore-production.iam.gserviceaccount.com%2F20240818%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240818T010705Z&X-Goog-Expires=14400&X-Goog-SignedHeaders=host&X-Goog-Signature=77d3cc5bc22a119693b9aeef813eaa6020878ba8fbb8a4c757e8fcbf96f0929dfbb17d6f428f031785f11c402246f807808dc0be8be96990a7d38884c7e17b7d53ecef2c7ac543680fdf7efe0a6f20d58622b016aed8e77f3ae0c9c4f2ce30acc33c0ec4d1264e5289283ecd88eb3059593e79f1d0f805982bfcc3c366409721c0e9da132aa8e9e3fdcb393f2fa37bf72abda967e01ea2cfb8ff3f90ab4d27c9f6c5ba44d523b26937e4d5891db781d8037b77317e63b89cf5f4b305f18f7f40944333c691498fd2c2350ff53f3146a8bb168eb093a9f498a016422ba1b0abec31a0bcd0828baa848dd0cc7c437991ce19293a8e92fdac1bdab6897403398f35)
 
-**Tags:** *#ai, #ai-governance, #ai-reliability, #cloud, #cloud-computing, #cybersecurity, #data-science, #developer-experience, #enterprise-architecture, #machine-learning*
+**Tags:** *#ai, #cloud-computing, #cybersecurity, #developer-experience, #enterprise-architecture*
 
 **Site Name:** None
 
@@ -203,7 +203,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [AI Gateways Transform Experimentation into Scalable Production - The New Stack](https://thenewstack.io/ai-gateways-transform-experimentation-into-scalable-production/)
 
-**Tags:** *#ai, #ai-governance, #ai-reliability, #ai-security, #deep-learning, #llm, #machine-learning, #nlp, #openai, #responsible-ai*
+**Tags:** *#ai, #llm, #ai-security, #ai-reliability, #responsible-ai*
 
 **Site Name:** The New Stack
 
@@ -213,7 +213,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [GraphRAG: Unlocking LLM discovery on narrative private data - Microsoft Research](https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/)
 
-**Tags:** *#ai, #data-science, #llm, #machine-learning, #rag, #private-datasets, #graph-machine-learning, #enterprise-research, #microsoft-research, #gpt-4*
+**Tags:** *#llm, #rag, #graph-machine-learning, #private-datasets, #microsoft-research*
 
 **Site Name:** Microsoft Research
 
@@ -223,7 +223,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [A look at Apple’s new Transformer-powered predictive text model](https://jackcook.com/2023/09/08/predictive-text.html)
 
-**Tags:** *#ai, #apple, #machine-learning, #transformer-language-model, #nlp, #macos, #ios, #predictive-text, #coreml, #language-model-architecture*
+**Tags:** *#apple, #machine-learning, #predictive-text, #coreml, #nlp*
 
 **Site Name:** jackcook.com
 
@@ -233,7 +233,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [How causal artificial intelligence is revolutionizing the pharmaceutical industry](https://www.nature.com/articles/d43747-024-00075-x)
 
-**Tags:** *#ai, #ai-reliability, #ai-optimization, #ai-security, #data-science, #deep-learning, #drug-development, #machine-learning, #causal-ai, #genetic-research*
+**Tags:** *#ai, #causal-ai, #drug-development, #machine-learning, #genetic-research*
 
 **Site Name:** nature.com
 
@@ -243,7 +243,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [10 profound answers about the math behind AI - Big Think](https://bigthink.com/starts-with-a-bang/10-answers-math-artificial-intelligence/?rjnrid=648JXmK)
 
-**Tags:** *#ai, #generative-ai, #machine-learning, #large-language-models, #artificial-intelligence, #deep-learning, #data-science, #neural-networks, #pattern-recognition, #mathematical-algorithms*
+**Tags:** *#ai, #machine-learning, #mathematical-algorithms, #neural-networks, #deep-learning*
 
 **Site Name:** Big Think
 
@@ -253,7 +253,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [What exactly is an AI agent? | TechCrunch](https://techcrunch.com/2024/07/13/what-exactly-is-an-ai-agent/)
 
-**Tags:** *#ai, #ai-governance, #ai-optimization, #ai-reliability, #ai-security, #machine-learning, #nlp, #deep-learning, #enterprise-architecture, #cloud-computing*
+**Tags:** *#ai, #ai-governance, #ai-reliability, #ai-security, #machine-learning*
 
 **Site Name:** TechCrunch
 
@@ -263,7 +263,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [The Math Behind Transformers | Medium](https://medium.com/@cristianleo120/the-math-behind-transformers-6d7710682a1f)
 
-**Tags:** *#llm, #transformers, #machine-learning, #nlp, #deep-learning, #python, #math, #attention-mechanism, #image-recognition, #positional-encoding*
+**Tags:** *#transformers, #llm, #machine-learning, #attention-mechanism, #positional-encoding*
 
 **Site Name:** Medium
 
@@ -273,7 +273,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Gen AI Increases Workloads and Decreases Productivity, Upwork Study Finds - InfoQ](https://www.infoq.com/news/2024/07/genai-hampers-productivity-study/)
 
-**Tags:** *#generative-ai, #ai, #ai-security, #ai-optimization, #ai-reliability, #data-science, #survey-analysis, #employee-productivity, #productivity-paradox, #skill-based-approach*
+**Tags:** *#generative-ai, #productivity-paradox, #survey-analysis, #employee-productivity, #ai-reliability*
 
 **Site Name:** InfoQ
 
@@ -285,11 +285,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## Enterprise Integration
 
-**Category Tags:** #architecture, #api-reliability, #api-security, #automation, #cloud-computing, #cyber-security, #developer-experience, #enterprise-architecture, #security, #integration-architecture
+**Category Tags:** #architecture, #enterprise-architecture, #integration-architecture, #api-security, #api-reliability
 
 ### [Architecting enterprise integrations | by Chathura Ekanayake | Jun, 2024 | Medium](https://chathura-ekanayake.medium.com/architecting-enterprise-integrations-30cc55b566fe)
 
-**Tags:** *#architecture, #api-reliability, #api-security, #automation, #cloud-computing, #cyber-security, #developer-experience, #enterprise-architecture, #security, #integration-architecture*
+**Tags:** *#architecture, #enterprise-architecture, #integration-architecture, #api-security, #api-reliability*
 
 **Site Name:** Medium
 
@@ -301,11 +301,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## Security and DevOps
 
-**Category Tags:** #access-control, #application-security, #attribute-based-access-control, #authentication, #authentication-methods, #authorization, #automation, #aws, #aws-security, #biometric-authentication, #cloud-computing, #cryptography, #cyber-security, #cybersecurity, #deep-learning, #ethical-ai, #http-sessions, #json-web-token, #multifactor-authentication, #oauth-2-0, #openid-connect, #reverse-engineering, #role-based-access-control, #security, #tokens, #web-cookies, #webdev
+**Category Tags:** #security, #authentication, #authorization, #aws-security, #cyber-security
 
 ### [Revealing the Inner Structure of AWS Session Tokens | by Tal Be'ery | Jul, 2024 | Medium](https://medium.com/@TalBeerySec/revealing-the-inner-structure-of-aws-session-tokens-a6c76469cba7)
 
-**Tags:** *#aws, #aws-security, #cloud-computing, #security, #ethical-ai, #cybersecurity, #reverse-engineering, #cryptography, #deep-learning, #automation*
+**Tags:** *#aws, #aws-security, #security, #cryptography, #reverse-engineering*
 
 **Site Name:** Medium
 
@@ -315,7 +315,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Securing your secrets in AWS - DEV Community](https://dev.to/aws-builders/securing-your-secrets-in-aws-kh5)
 
-**Tags:** *#aws, #cloud-computing, #cyber-security, #security, #developer-experience, #machine-to-machine-authentication, #api-security, #ci-cd, #aws-secrets-manager, #key-management*
+**Tags:** *#aws, #aws-secrets-manager, #security, #api-security, #key-management*
 
 **Site Name:** DEV Community
 
@@ -325,7 +325,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Authentication vs authorization: understanding the difference | CNCF](https://www.cncf.io/blog/2024/07/23/authentication-vs-authorization-understanding-the-difference/)
 
-**Tags:** *#security, #authentication, #authorization, #application-security, #access-control, #authentication-methods, #multifactor-authentication, #biometric-authentication, #role-based-access-control, #attribute-based-access-control*
+**Tags:** *#security, #authentication, #authorization, #access-control, #application-security*
 
 **Site Name:** CNCF
 
@@ -335,7 +335,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Demystifying cookies and tokens – Tommi Hovi | The Security blog](https://tommihovi.com/2024/05/demystifying-cookies-and-tokens/)
 
-**Tags:** *#webdev, #automation, #cyber-security, #web-cookies, #authentication, #tokens, #http-sessions, #json-web-token, #oauth-2-0, #openid-connect*
+**Tags:** *#web-cookies, #authentication, #tokens, #json-web-token, #openid-connect*
 
 **Site Name:** tommihovi.com
 
@@ -347,11 +347,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## Kubernetes
 
-**Category Tags:** #automation, #aws, #azure, #cloud, #cloud-computing, #cluster-management, #coding-best-practices, #containers, #context-management, #data-science, #developer-experience, #devops, #kubeconfig, #kubectl, #kubernetes, #kubernetes-best-practices, #multiple-clusters
+**Category Tags:** #kubernetes, #kubectl, #kubeconfig, #containers, #devops
 
 ### [Kubectl Get Context : Current Context, Switching & Listing](https://spacelift.io/blog/kubectl-get-context)
 
-**Tags:** *#kubernetes, #cloud-computing, #devops, #containers, #cluster-management, #kubeconfig, #context-management, #kubectl, #multiple-clusters, #kubernetes-best-practices*
+**Tags:** *#kubernetes, #kubectl, #kubeconfig, #cluster-management, #multiple-clusters*
 
 **Site Name:** Spacelift
 
@@ -363,11 +363,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## Python
 
-**Category Tags:** #conda, #environment, #packages, #pip, #pip3, #python, #requirements, #venv, #virtualenv, #virtualization, #uv, #package-installer, #rust, #dependency-management, #development-tools, #python-package, #fast-installer, #project-management, #high-confidence
+**Category Tags:** #python, #package-installer, #dependency-management, #virtualenv, #uv
 
 ### [python - From conda create requirements.txt for pip3 - Stack Overflow](https://stackoverflow.com/questions/50777849/from-conda-create-requirements-txt-for-pip3)
 
-**Tags:** *#conda, #virtualization, #pip3, #virtualenv, #requirements, #environment, #pip, #venv, #python, #packages*
+**Tags:** *#python, #conda, #requirements, #pip, #virtualenv*
 
 **Site Name:** Stack Overflow
 
@@ -377,7 +377,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Forget `pip install`, Use This Instead | by Benedict Neo | bitgrit Data Science Publication | Medium](https://medium.com/bitgrit-data-science-publication/forget-pip-install-use-this-instead-754863c58f1e)
 
-**Tags:** *#python, #uv, #package-installer, #rust, #dependency-management, #development-tools, #python-package, #fast-installer, #project-management, #high-confidence*
+**Tags:** *#python, #uv, #package-installer, #dependency-management, #python-package*
 
 **Site Name:** bitgrit Data Science Publication
 
@@ -389,11 +389,11 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ## Developer Tools & Productivity
 
-**Category Tags:** #api, #aws, #awscli, #bat, #btop, #cat, #cloud, #coding, #ctop, #developer-productivity, #development, #devops, #dive, #dust, #markdown, #open-source, #shell, #terminal, #tools, #workflow-productivity, #data-analysis, #devx, #participant-demographics, #response-rate, #salary-information, #stack-overflow, #survey, #survey-difficulty, #survey-length, #user-experience
+**Category Tags:** #tools, #developer-productivity, #terminal, #shell, #markdown
 
 ### [New Computer Setup for Techies 2024: NeoVim and Ollama and fish, oh my! | by Melissa Richard | Medium](https://medium.com/@devhellomello/new-computer-setup-for-techies-2024-neovim-and-ollama-and-fish-oh-my-60cf3879bad8)
 
-**Tags:** *#developer-productivity, #tools, #cloud, #coding, #development, #devops, #terminal, #markdown, #api, #open-source, #workflow-productivity*
+**Tags:** *#developer-productivity, #tools, #terminal, #markdown, #open-source*
 
 **Site Name:** Medium
 
@@ -403,7 +403,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Command Line Tools I use on a Mac | by Brian Schlining | May, 2024 | Medium](https://schlining.medium.com/command-line-tools-i-use-on-a-mac-b47c98efd0af)
 
-**Tags:** *#aws, #shell, #tools, #awscli, #bat, #cat, #btop, #ctop, #dive, #dust*
+**Tags:** *#shell, #tools, #awscli, #bat, #btop*
 
 **Site Name:** Medium
 
@@ -413,7 +413,7 @@ tags: ["access-control", "ai", "ai-governance", "ai-optimization", "ai-reliabili
 
 ### [Methodology | 2024 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2024/methodology/)
 
-**Tags:** *#devx, #survey, #data-analysis, #stack-overflow, #salary-information, #user-experience, #response-rate, #survey-length, #survey-difficulty, #participant-demographics*
+**Tags:** *#devx, #survey, #data-analysis, #stack-overflow, #user-experience*
 
 **Site Name:** survey.stackoverflow.co
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,13 @@ baseURL = 'http://waltodders.com'
 languageCode = 'en-us'
 title = 'Todd Walters Blog'
 
+[author]
+  name = "Todd Walters"
+  github = "toddwalters"
+  linkedin = "toddwalters"
+  twitter = "toddwalters"
+  website = "https://waltodders.com"
+
 # Syntax highlighting
 pygmentsCodeFences = true
 pygmentsUseClasses = true

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -88,7 +88,7 @@
           </div>
           {{ else }}
           <div class="disqus-comments">
-            {{ template "_internal/disqus.html" . }}
+            {{/* Hugo v0.158 no longer ships the legacy embedded Disqus template. */}}
           </div>
           {{ end }}
         {{ end }}

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,0 +1,1 @@
+{{/* Local compatibility override for legacy theme Disqus partials on newer Hugo versions. */}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,137 @@
+{{ if eq .Type "page" }}
+  {{ partial "page_meta.html" . }}
+{{ end }}
+<footer>
+  <div class="container">
+    {{ if .Site.Params.disclaimerText }}
+    <div class="row">
+      <div class="disclaimer">
+        <b>Disclaimer:</b> {{ .Site.Params.disclaimerText }}
+      </div>
+    </div>
+    {{ end }}
+    <div class="row">
+      <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+        <ul class="list-inline text-center footer-links">
+          {{ range .Site.Data.beautifulhugo.social.social_icons }}
+            {{- if isset $.Site.Params.author .id }}
+              <li>
+                {{ if or ( hasPrefix ( index $.Site.Params.author .id ) "http://" ) ( hasPrefix ( index $.Site.Params.author .id ) "https://" ) }}
+                  <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf "%s" (index $.Site.Params.author .id) }}" title="{{ .title }}">
+                {{ else }}
+                  <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf .url (index $.Site.Params.author .id) }}" title="{{ .title }}">
+                {{ end }}
+                  <span class="fa-stack fa-lg">
+                    <i class="fas fa-circle fa-stack-2x"></i>
+                    <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
+                  </span>
+                </a>
+              </li>
+            {{- end -}}
+          {{ end }}
+          {{ if .Site.Params.rss }}
+          <li>
+            <a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" title="RSS">
+              <span class="fa-stack fa-lg">
+                <i class="fas fa-circle fa-stack-2x"></i>
+                <i class="fas fa-rss fa-stack-1x fa-inverse"></i>
+              </span>
+            </a>
+          </li>
+          {{ end }}
+        </ul>
+        <p class="credits copyright text-muted">
+          {{ if .Site.Params.author.name }}
+            {{ if .Site.Params.author.website }}
+              <a href="{{ .Site.Params.author.website }}">{{ .Site.Params.author.name }}</a>
+            {{ else }}
+              {{ .Site.Params.author.name }}
+            {{ end }}
+          {{ end }}
+
+          &nbsp;&bull;&nbsp;&copy;
+          {{ if .Site.Params.since }}
+            {{ .Site.Params.since }} - {{ now.Format "2006" }}
+          {{ else }}
+            {{ now.Format "2006" }}
+          {{ end }}
+
+          {{ if .Site.Title }}
+            &nbsp;&bull;&nbsp;
+            <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
+          {{ end }}
+        </p>
+        <p class="credits theme-by text-muted">
+          {{ i18n "poweredBy" . | safeHTML }}
+          {{ if $.GitInfo }}&nbsp;&bull;&nbsp;[<a href="{{ .Site.Params.commit }}{{ .GitInfo.Hash }}">{{ substr .GitInfo.Hash 0 8 }}</a>]{{ end }}
+        </p>
+      </div>
+    </div>
+  </div>
+</footer>
+
+{{- if .Site.Params.selfHosted -}}
+<script defer src="{{ "js/katex.min.js" | absURL }}"></script>
+<script defer src="{{ "js/auto-render.min.js" | absURL }}" onload="renderMathInElement(document.body);"></script>
+<script src="{{ "js/jquery-3.7.0.slim.min.js" | absURL }}"></script>
+<script src="{{ "js/bootstrap.min.js" | absURL }}"></script>
+{{- else -}}
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/katex.min.js" integrity="sha384-G0zcxDFp5LWZtDuRMnBkk3EphCK1lhEf4UEyEM693ka574TZGwo4IWwS6QLzM/2t" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
+<script src="https://code.jquery.com/jquery-3.7.0.slim.min.js" integrity="sha384-w5y/xIeYixWvfM+A1cEbmHPURnvyqmVg5eVENruEdDjcyRLUSNej7512JQGspFUr" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
+{{- end }}
+
+<script src="{{ "js/main.js" | absURL }}"></script>
+{{- if .Site.Params.staticman }}
+<script src="{{ "js/staticman.js" | absURL }}"></script>
+{{- end }}
+{{- if  .Site.Params.useHLJS }}
+<script src="{{ "js/highlight.min.js" | absURL }}"></script>
+<script> hljs.initHighlightingOnLoad(); </script>
+<script> $(document).ready(function() {$("pre.chroma").css("padding","0");}); </script>
+{{- end -}}
+
+{{- if .Site.Params.selfHosted -}}
+<script src="{{ "js/photoswipe.min.js" | absURL }}"></script>
+<script src="{{ "js/photoswipe-ui-default.min.js" | absURL }}"></script>
+{{- else -}}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe.min.js" integrity="sha384-QELNnmcmU8IR9ZAykt67vGr9/rZJdHbiWi64V88fCPaOohUlHCqUD/unNN0BXSqy" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe-ui-default.min.js" integrity="sha384-m67o7SkQ1ALzKZIFh4CiTA8tmadaujiTa9Vu+nqPSwDOqHrDmxLezTdFln8077+q" crossorigin="anonymous"></script>
+{{- end -}}
+<script src="{{ "js/load-photoswipe.js" | absURL }}"></script>
+
+{{ if .Site.Params.gcse }}
+<script>
+  (function() {
+    var cx = '{{ .Site.Params.gcse }}';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+{{ end }}
+
+{{ if .Site.Params.piwik }}
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(["trackPageView"]);
+  _paq.push(["enableLinkTracking"]);
+
+  (function() {
+    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://{{ .Site.Params.piwik.server }}/";
+    _paq.push(["setTrackerUrl", u+"piwik.php"]);
+    _paq.push(["setSiteId", "{{ .Site.Params.piwik.id }}"]);
+    var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
+    g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript>
+<img src="http://{{ .Site.Params.piwik.server }}/piwik.php?idsite={{ .Site.Params.piwik.id }}&amp;rec=1" style="border:0" alt="" />
+</noscript>
+{{ end }}
+
+{{- partial "footer_custom.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,101 @@
+{{- if eq .Kind "taxonomyTerm" }}
+  {{- range $key, $value := .Data.Terms.ByCount }}
+    {{- $.Scratch.Add "most_used" (slice $value.Name) }}
+  {{- end }}
+  {{- if not ($.Scratch.Get "most_used") }}
+    {{- $description := printf "A full overview of all pages with %s, ordered by %s" .Data.Plural .Data.Singular | truncate 180 }}
+    {{- $.Scratch.Set "Description" $description }}
+  {{- else }}
+    {{- $description := printf "A full overview of all pages with %s, ordered by %s, such as: %s" .Data.Plural .Data.Singular ( delimit ( $.Scratch.Get "most_used" ) ", " ", and " ) | truncate 180 }}
+    {{- $.Scratch.Set "Description" $description }}
+  {{- end }}
+
+  {{- $title := printf "Overview of all pages with %s, ordered by %s" .Data.Plural .Data.Singular }}
+  {{- $.Scratch.Set "Title" $title }}
+{{- else if eq .Kind "taxonomy" }}
+  {{- $description := printf "Overview of all pages with the %s #%s, such as: %s" .Data.Singular $.Title ( index .Pages 0).Title | truncate 160 }}
+  {{- $.Scratch.Set "Description" $description }}
+
+  {{- $title := printf "Overview of all pages with the %s #%s" .Data.Singular $.Title }}
+  {{- $.Scratch.Set "Title" $title }}
+{{- else }}
+  {{- $.Scratch.Set "Description" ( .Description | default .Params.subtitle | default .Summary ) }}
+  {{- $.Scratch.Set "Title" ( .Title | default .Site.Title ) }}
+{{- end }}
+
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+ <!-- Site Title, Description, Author, and Favicon -->
+
+{{ if .IsHome }}
+    {{- with .Site.Params.homeTitle }}
+      <title>{{ . }}</title>
+    {{- end }}
+  {{ else }}
+    {{- with ($.Scratch.Get "Title") }}
+      <title>{{ . }} - {{ $.Site.Params.homeTitle }}</title>
+    {{- end }}
+{{ end }}
+
+{{- with ($.Scratch.Get "Description") }}
+  <meta name="description" content="{{ . }}">
+{{- end }}
+{{- with .Site.Params.author.name }}
+  <meta name="author" content="{{ . }}"/>
+{{- end }}
+{{- with .Site.Params.favicon }}
+  <link href='{{ . | absURL }}' rel='icon' type='image/x-icon'/>
+{{- end -}}
+<!-- Hugo Version number -->
+  {{ hugo.Generator -}}
+<!-- Links and stylesheets -->
+  <link rel="alternate" href="{{ "index.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
+
+  {{- if .Site.Params.selfHosted -}}
+  <link rel="stylesheet" href="{{ "css/katex.min.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "fontawesome/css/all.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/bootstrap.min.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/katex.min.css" integrity="sha384-3UiQGuEI4TTMaFmGIZumfRPtfKQ3trwQE2JgosJxCnGmQpL/lJdjpcHkaaFwHlcI" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+  {{- end -}}
+
+  <link rel="stylesheet" href="{{ "css/main.css" | absURL }}" />
+
+  {{- if .Site.Params.staticman -}}
+  <link rel="stylesheet" href="{{ "css/staticman.css" | absURL }}" />
+  {{- end -}}
+
+  {{- if .Site.Params.selfHosted -}}
+  <link rel="stylesheet" href="{{ "css/fonts.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
+  {{- end -}}
+
+  {{- if .Site.Params.useHLJS }}
+  <link rel="stylesheet" href="{{ "css/highlight.min.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="{{ "css/syntax.css" | absURL }}" />
+  {{- end -}}
+  <link rel="stylesheet" href="{{ "css/codeblock.css" | absURL }}" />
+  
+  {{- if .Site.Params.staticman.recaptcha -}}
+  <script src='https://www.google.com/recaptcha/api.js'></script>
+  {{- end -}}
+
+  {{- if .Site.Params.selfHosted -}}
+  <link rel="stylesheet" href="{{ "css/photoswipe.min.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/photoswipe.default-skin.min.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe.min.css" integrity="sha384-h/L2W9KefUClHWaty3SLE5F/qvc4djlyR4qY3NUV5HGQBBW7stbcfff1+I/vmsHh" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/default-skin/default-skin.min.css" integrity="sha384-iD0dNku6PYSIQLyfTOpB06F2KCZJAKLOThS5HRe8b3ibhdEQ6eKsFf/EeFxdOt5R" crossorigin="anonymous">
+  {{- end -}}
+
+{{- partial "head_custom.html" . }}
+{{- if not hugo.IsServer -}}
+  {{ template "_internal/google_analytics.html" . }}
+{{- end -}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,0 +1,95 @@
+<nav class="navbar navbar-default navbar-fixed-top navbar-custom">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#main-navbar">
+        <span class="sr-only">{{ i18n "toggleNavigation" }}</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
+    </div>
+
+    <div class="collapse navbar-collapse" id="main-navbar">
+      <ul class="nav navbar-nav navbar-right">
+        {{ range .Site.Menus.main.ByWeight }}
+          {{ if .HasChildren }}
+            <li class="navlinks-container">
+              <a class="navlinks-parent">{{ .Name }}</a>
+              <div class="navlinks-children">
+                {{ range .Children }}
+                  <a href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+                {{ end }}
+              </div>
+            </li>
+          {{ else }}
+            <li>
+              <a title="{{ .Name }}" href="{{ .URL  | relLangURL }}">{{ .Name }}</a>
+            </li>
+          {{ end }}
+        {{ end }}
+
+        {{ if gt (len .Site.Languages) 1 }}
+          {{ if ge (len .Site.Languages) 3 }}
+            <li class="navlinks-container">
+              <a class="navlinks-parent">{{ i18n "languageSwitcherLabel" }}</a>
+              <div class="navlinks-children">
+                {{ range .Translations }}
+                  {{ if not (eq .Lang $.Site.Language.Lang) }}
+                  <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
+                  {{ end }}
+                {{ end }}
+              </div>
+            </li>
+          {{ else }}
+            <li>
+              {{ if .IsTranslated }}
+                {{ range .Translations }}
+                  <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
+                {{ end}}
+              {{ end }}
+            </li>
+          {{ end }}
+        {{ end }}
+
+        {{ if isset .Site.Params "gcse" }}
+          <li>
+            <a href="#modalSearch" data-toggle="modal" data-target="#modalSearch" style="outline: none;">
+              <span class="hidden-sm hidden-md hidden-lg">{{ i18n "gcseLabelShort" }}</span> <span id="searchGlyph" class="glyphicon glyphicon-search"></span>
+            </a>
+          </li>
+        {{ end }}
+      </ul>
+    </div>
+
+    {{ if isset .Site.Params "logo" }}
+      <div class="avatar-container">
+        <div class="avatar-img-border">
+          <a title="{{ .Site.Title }}" href="{{ "" | absLangURL }}">
+            <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}" />
+          </a>
+        </div>
+      </div>
+    {{ end }}
+
+  </div>
+</nav>
+
+{{ if isset .Site.Params "gcse" }}
+  <div id="modalSearch" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h4 class="modal-title">{{ i18n "gcseLabelLong" . }}</h4>
+        </div>
+        <div class="modal-body">
+          <gcse:search></gcse:search>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">{{ i18n "gcseClose" }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,0 +1,50 @@
+<span class="post-meta">
+  {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
+  {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
+  <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
+  {{ if ne $datestr $lastmodstr }}
+    &nbsp;{{ $lastmodstr | i18n "lastModified"  }}
+  {{ end }}
+  {{ if .Site.Params.readingTime }}
+    &nbsp;|&nbsp;<i class="fas fa-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" }}
+  {{ end }}
+  {{ if .Site.Params.wordCount }}
+    &nbsp;|&nbsp;<i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
+  {{ end }}
+  {{ if not .Site.Params.hideAuthor }}
+    {{ if .Params.author }}
+      {{ if reflect.IsSlice .Params.author }}
+        {{ range .Params.author }}
+          &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ . | safeHTML }}
+        {{ end }}
+      {{ else }}
+        &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Params.author | safeHTML }}
+      {{ end }}
+    {{ else }}
+      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Site.Params.author.name | safeHTML }}
+    {{ end }}
+  {{ end }}
+  {{- if .Site.Params.staticman -}}
+    &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
+    {{ $slug := replace .RelPermalink "/" "" }}
+    {{ if .Site.Data.comments }}
+      {{ $comments := index $.Site.Data.comments $slug }}
+      {{ if $comments }}
+        {{ if gt (len $comments) 1  }}
+          {{ len $comments  }} {{ i18n "moreComment" }}
+        {{ else }}
+          {{ len $comments  }} {{ i18n "oneComment" }}
+        {{ end }}
+      {{ else }}
+        0 {{ i18n "oneComment" }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ if .IsTranslated -}}
+    {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}
+    {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
+    {{- $cleanLinks := apply $links "chomp" "." -}}
+    {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
+    &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}{{ $linksOutput | safeHTML }}
+  {{- end }}
+</span>

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -4,7 +4,7 @@
     <ul class="share">
       <!-- Twitter -->
       <li>
-        <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Author.twitter }}" target="_blank" title="Share on Twitter">
+        <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.author.twitter }}" target="_blank" title="Share on Twitter">
           <i class="fab fa-twitter"></i>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- reduce front matter and inline tag sections across posts to 5 or fewer curated tags
- normalize a few malformed tag spellings while trimming the roundup posts
- add local Hugo/theme compatibility overrides so the site builds and runs under the current Hugo version

## Validation
- `hugo --gc --minify`
- `hugo server -D --bind 127.0.0.1 --baseURL http://127.0.0.1:1313/`
