### PR TITLE
[codex] Update GitHub Pages actions

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- replace deprecated GitHub Pages action versions in the Hugo deployment workflow
- move the workflow to the current supported Pages action majors to restore CI

## Root Cause
GitHub now rejects the deprecated artifact action path used by `actions/upload-pages-artifact@v2`, so the workflow failed during job setup before the Hugo build even started.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hugo.yaml"); puts "workflow yaml ok"'`
- inspected failed Actions run `23990215149`