### PR TITLE
[codex] Bump Pages workflow Hugo version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.121.0
+      HUGO_VERSION: 0.158.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
## Summary\n- bump the GitHub Pages workflow from Hugo 0.121.0 to 0.158.0\n- align production builds with the local Hugo version already used for preview and validation\n\n## Testing\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hugo.yaml"); puts "workflow yaml ok"'\n- hugo --gc --minify --baseURL http://example.org/\n